### PR TITLE
add pipx install command & add swig hint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ pip install donpapi
 
 or
 
-```
+```bash
 git clone https://github.com/login-securite/DonPAPI.git
 cd DonPAPI
 python3 -m pip install .
@@ -47,11 +47,19 @@ DonPAPI
 
 or
 
-```
+```bash
+# make shure that "swig" is installed and available in your path to build "m2crypto" correctly
 git clone git+https://github.com/login-securite/DonPAPI.git
 cd DonPAPI
 poetry update
 poetry run DonPAPI
+```
+
+or
+
+```bash
+# make shure that "swig" is installed and available in your path to build "m2crypto" correctly
+pipx install git+https://github.com/login-securite/DonPAPI.git
 ```
 
 ## Helper 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ DonPAPI
 or
 
 ```bash
-# make shure that "swig" is installed and available in your path to build "m2crypto" correctly
+# make sure that "swig" is installed and available in your path to build "m2crypto" correctly
 git clone git+https://github.com/login-securite/DonPAPI.git
 cd DonPAPI
 poetry update
@@ -58,7 +58,7 @@ poetry run DonPAPI
 or
 
 ```bash
-# make shure that "swig" is installed and available in your path to build "m2crypto" correctly
+# make sure that "swig" is installed and available in your path to build "m2crypto" correctly
 pipx install git+https://github.com/login-securite/DonPAPI.git
 ```
 


### PR DESCRIPTION
To install DonPAPI with poetry or pipx, the package must be built locally. To correctly build the m2crypto dependency, you need to install the "swig" tool. It is available as a package for most distros out there.