### PR TITLE
Fix LDAP search for domains with numerous computers

### DIFF
--- a/donpapi/entry.py
+++ b/donpapi/entry.py
@@ -141,10 +141,13 @@ def fetch_all_computers(options):
                 options.lmhash,
                 options.nthash,
             )
+
+        paged_search_control = ldapasn1.SimplePagedResultsControl(criticality=True, size=1000)
+
         results = ldap_connection.search(
             searchFilter=ldap_filter,
             attributes=attributes,
-            sizeLimit=0,
+            searchControls=[paged_search_control],
         )  
     except Exception as e:
         donpapi_logger.error(f"Exception while requesting targets: {e}")


### PR DESCRIPTION
This PR fixes an issue for domains with over 1000 computers, which cannot be fetched using a non-paged LDAP query.

The fix comes from this issue : https://github.com/fortra/impacket/issues/1485#issuecomment-1433231176