### PR TITLE
Add false posittives for collectors

### DIFF
--- a/donpapi/collectors/firefox.py
+++ b/donpapi/collectors/firefox.py
@@ -49,6 +49,8 @@ class FirefoxDump:
         "Default",
         "Default User",
         "All Users",
+        ".NET v4.5", 
+        ".NET v4.5 Classic"
     )
 
     def __init__(self, target: Target, conn: DPLootSMBConnection, masterkeys: list, options: Any, logger: DonPAPIAdapter, context: DonPAPICore) -> None:

--- a/donpapi/collectors/recent_files.py
+++ b/donpapi/collectors/recent_files.py
@@ -11,7 +11,7 @@ from donpapi.lib.logger import DonPAPIAdapter
 TAG = "Files"
 
 class FilesDump:
-    false_positive = ['.','..', 'desktop.ini','Public','Default','Default User','All Users']
+    false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
     user_directories = ["Users\\{username}\\Recent", "Users\\{username}\\Desktop"]
     mask = ['xls','pdf','doc','txt','lnk','kbdx','xml','config','conf','bat','sh']
     max_filesize = 5000000


### PR DESCRIPTION
This small PR adds two false positiv usernames (.NET v4.5 et .NET v4.5 Classic) to collectors that use this list.