### PR TITLE
Fix SAM dump error when remote registry is disabled OR EDR blocks it

### DIFF
--- a/donpapi/core.py
+++ b/donpapi/core.py
@@ -264,7 +264,7 @@ class DonPAPICore:
             # Dump SAM
             self.logger.display("Dumping SAM")
             self.dump_sam()
-            if self.sam_dump.items_found:
+            if hasattr(self.sam_dump, 'items_found') and self.sam_dump.items_found is not None:
                 self.logger.secret(f"Got {len(self.sam_dump.items_found)} accounts", "SAM")
             else:
                 self.logger.fail(f"No account found in SAM (maybe blocked by EDR)")

--- a/donpapi/core.py
+++ b/donpapi/core.py
@@ -264,7 +264,7 @@ class DonPAPICore:
             # Dump SAM
             self.logger.display("Dumping SAM")
             self.dump_sam()
-            if hasattr(self.sam_dump, 'items_found') and self.sam_dump.items_found is not None:
+            if hasattr(self.sam_dump, "items_found") and self.sam_dump.items_found is not None:
                 self.logger.secret(f"Got {len(self.sam_dump.items_found)} accounts", "SAM")
             else:
                 self.logger.fail(f"No account found in SAM (maybe blocked by EDR)")


### PR DESCRIPTION
This PR fixes the following error:

![image](https://github.com/user-attachments/assets/ab8982c2-cb58-44e7-8fd0-650fe8cb0ea4)
 
(see https://github.com/login-securite/DonPAPI/issues/79)

By adding the following line to core.py (line 267): 

```python
if hasattr(self.sam_dump, "items_found") and self.sam_dump.items_found is not None:
    self.logger.secret(f"Got {len(self.sam_dump.items_found)} accounts", "SAM")
else:
    self.logger.fail(f"No account found in SAM (maybe blocked by EDR)")
```

That way, we make sure that there is a items_found attribute and DonPAPI doesn't crash anymore.