### PR TITLE
Fix secretsdump not able to retrieve autologon default username

### DIFF
--- a/donpapi/lib/secretsdump.py
+++ b/donpapi/lib/secretsdump.py
@@ -239,3 +239,19 @@ class DonPAPIRemoteOperations:
         self.logger.verbose(f"Downloading hive on share: {self.share_name} on filepath: {tmpFilePath}")
         remoteFileName = RemoteFile(self.smb_connection, tmpFilePath, shareName=self.share_name)
         return remoteFileName
+    
+    def getDefaultLoginAccount(self):
+        try:
+            ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, 'SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon')
+            keyHandle = ans['phkResult']
+            dataType, dataValue = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'DefaultUserName')
+            username = dataValue[:-1]
+            dataType, dataValue = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'DefaultDomainName')
+            domain = dataValue[:-1]
+            rrp.hBaseRegCloseKey(self.__rrp, keyHandle)
+            if len(domain) > 0:
+                return '%s\\%s' % (domain,username)
+            else:
+                return username
+        except:
+            return None


### PR DESCRIPTION
As of now, DonPAPI isn't able to retrieve the default username used for autologon:

![image](https://github.com/user-attachments/assets/845fd2bc-91b1-4a02-bdd0-1e29bcb9fa30)

This is because in the secretdumps DonPAPIRemoteOperations, the getDefaultLoginAccount function was omitted. As such, I added this piece of code (line 3268):

```python
def getDefaultLoginAccount(self):
        try:
            ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, 'SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon')
            keyHandle = ans['phkResult']
            dataType, dataValue = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'DefaultUserName')
            username = dataValue[:-1]
            dataType, dataValue = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'DefaultDomainName')
            domain = dataValue[:-1]
            rrp.hBaseRegCloseKey(self.__rrp, keyHandle)
            if len(domain) > 0:
                return '%s\\%s' % (domain,username)
            else:
                return username
        except:
            return None
```

DonPAPIRemoteOperations having the necessary function, it can now retrieve this value and print the correct value:

![image](https://github.com/user-attachments/assets/ae01b0c6-edcb-4c4e-a763-20f42e7b6e39)


Note: before merging, this branch will be in conflit with this PR:
* https://github.com/login-securite/DonPAPI/pull/98