### PR TITLE
Fix No module named 'collectors'

### DIFF
--- a/donpapi/entry.py
+++ b/donpapi/entry.py
@@ -53,10 +53,10 @@ def load_collectors(root, collectors_list) -> Tuple[List, List] :
     for _, collector_name, _ in iter_modules(path=[f"{root}/collectors/"]):
         available_collectors.append(collector_name)
         if "All" in collectors_list:
-            loaded_collectors.append(getattr(import_module(f"collectors.{collector_name}"), collector_name))
+            loaded_collectors.append(getattr(import_module(f"donpapi.collectors.{collector_name}"), collector_name))
         else:
             if collector_name in collectors_list:
-                loaded_collectors.append(getattr(import_module(f"collectors.{collector_name}"), collector_name))
+                loaded_collectors.append(getattr(import_module(f"donpapi.collectors.{collector_name}"), collector_name))
     return available_collectors, loaded_collectors
 
 def fetch_all_computers(options):


### PR DESCRIPTION
This PR fixes the following error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\Administrator\Desktop\DonPAPI\donpapi\entry.py", line 333, in main
    _, collectors = load_collectors(root, options.collectors.split(","))
  File "C:\Users\Administrator\Desktop\DonPAPI\donpapi\entry.py", line 56, in load_collectors
    loaded_collectors.append(getattr(import_module(f"collectors.{collector_name}"), collector_name))
  File "C:\Python39\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'collectors'
```

Updated the import path in the load_collectors function.