### PR TITLE
[Feature] Add configuration option for excluding specific collectors as well as using a custom predefined set of collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ or (to dev)
 ```text
 git clone git+https://github.com/login-securite/DonPAPI.git
 cd DonPAPI
-poetry update
+poetry install
 poetry run DonPAPI
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ authentication:
 
 attacks:
   -c COLLECTORS, --collectors COLLECTORS
-                        Chromium, Certificates, CredMan, Files, Firefox, MobaXterm, MRemoteNG, RDCMan, SCCM, Vaults, VNC, Wifi, All (all
+                        Chromium, Certificates, CredMan, Files, Firefox, MobaXterm, MRemoteNG, RDCMan, SCCM, Vaults, VNC, Wifi, Custom (as specified in config), All (all
                         previous) (default: All)
   -nr, --no-remoteops   Disable Remote Ops operations (basically no Remote Registry operations, no DPAPI System Credentials)
   --fetch-pvk           Will automatically use domain backup key from database, and if not already dumped, will dump it on a domain controller
@@ -181,7 +181,16 @@ share = C$
 remote_filepath = \Users\Default\AppData\Local\Temp
 filename_regex = \d{4}-\d{4}-\d{4}-[0-9]{4}
 file_extension = .log
-``` 
+```
+
+#### Collectors config
+
+The collectors section in the config offers the option to define a custom set of collectors to run, as well as to specify collectors that will always be excluded (for example when using 'All' as collector). The config file is located at ~/.donpapi/donpapi.conf.
+```toml
+[collectors]
+collectors_list = Chromium,Firefox,CredMan,MobaXterm,MRemoteNG,RDCMan,SCCM,Vaults,VNC,Wifi
+always_exclude = 
+```
 
 #### Recover
 

--- a/donpapi/lib/config.py
+++ b/donpapi/lib/config.py
@@ -8,6 +8,8 @@ DEFAULT_CUSTOM_SHARE = "C$"
 DEFAULT_REMOTE_FILEPATH = "\\Users\\Default\\AppData\\Local\\Temp"
 DEFAULT_FILENAME_REGEX = r"\d{4}-\d{4}-\d{4}-[0-9]{4}"
 DEFAULT_FILE_EXTENSION = ".log"
+DEFAULT_CUSTOM_COLLECTORS_LIST = "Chromium,Firefox,CredMan,MobaXterm,MRemoteNG,RDCMan,SCCM,Vaults,VNC,Wifi"
+DEFAULT_ALWAYS_EXCLUDE_COLLECTORS = ""
 
 @dataclass
 class DonPAPIConfig:
@@ -15,12 +17,14 @@ class DonPAPIConfig:
     custom_remote_filepath: str = DEFAULT_REMOTE_FILEPATH
     custom_filename_regex: str = DEFAULT_FILENAME_REGEX
     custom_file_extension: str = DEFAULT_FILE_EXTENSION
+    custom_collectors_list: str = DEFAULT_CUSTOM_COLLECTORS_LIST
+    always_exclude_collectors: str = DEFAULT_ALWAYS_EXCLUDE_COLLECTORS
 
 def parse_config_file():
     donpapi_config = configparser.ConfigParser()
     donpapi_config.read(DPP_CONFIG_FILE_PATH)
 
-    if "secretsdump" not in donpapi_config.sections():
+    if "secretsdump" not in donpapi_config.sections() or "collectors" not in donpapi_config.sections():
         first_run()
         donpapi_config.read(DPP_CONFIG_FILE_PATH)
 
@@ -29,4 +33,6 @@ def parse_config_file():
         custom_remote_filepath = donpapi_config.get("secretsdump", "remote_filepath", fallback=DEFAULT_REMOTE_FILEPATH),
         custom_filename_regex = donpapi_config.get("secretsdump", "filename_regex", fallback=DEFAULT_FILENAME_REGEX),
         custom_file_extension = donpapi_config.get("secretsdump", "file_extension", fallback=DEFAULT_FILE_EXTENSION),
+        custom_collectors_list = donpapi_config.get("collectors", "collectors_list", fallback=DEFAULT_CUSTOM_COLLECTORS_LIST),
+        always_exclude_collectors = donpapi_config.get("collectors", "always_exclude", fallback=DEFAULT_ALWAYS_EXCLUDE_COLLECTORS),
     )

--- a/donpapi/lib/utils.py
+++ b/donpapi/lib/utils.py
@@ -12,6 +12,9 @@ from donpapi.lib.logger import donpapi_logger
 def create_recover_file(dirpath, targets, options):
     timestamp = int(time.time())
     filepath = os.path.join(dirpath, DPP_RECOVER_DIR_NAME, f"recover_{timestamp}")
+    recover_dirpath = os.path.join(dirpath, DPP_RECOVER_DIR_NAME)
+    if not os.path.exists(recover_dirpath):
+        os.makedirs(recover_dirpath)
     with open(filepath, "w") as f:
         write_recover_file(f, [f"{json.dumps(vars(options))}\n", ",".join(targets)])
 

--- a/donpapi/res/donpapi.conf
+++ b/donpapi/res/donpapi.conf
@@ -3,3 +3,6 @@ share = C$
 remote_filepath = \Users\Default\AppData\Local\Temp
 filename_regex = \d{4}-\d{4}-\d{4}-[0-9]{4}
 file_extension = .log
+[collectors]
+collectors_list = Certificates,Chromium,CloudCredentials,CredMan,Firefox,IDEProjects,MRemoteNG,MobaXTerm,NotepadPP,PasswordManagers,PowerShellHistory,RDCMan,RecentFiles,RecycleBin,SCCM,SSHSecrets,VNC,Vaults,VersionControlSystems,Wam,Wifi
+always_exclude = 


### PR DESCRIPTION
To make the handling of collectors easier i added two configuration options for choosing collectors.
This configuration is implement analogue to the already existing secretsdump options in the _donpapi.conf_.
Both features can be considered as nice to have.

- The first option _collectors_list_ specifies a list of collectors, which then can be used with _-c Custom_ (analogue to _-c All_). This makes it easier when using a large set of collectors, as you can use the shortcut _Custom_ to select your preferred collectors.
- The second option _always_exclude_ specifies a list of collectors, which will always be excluded from the loaded collectors even when they are specifically named with the _-c_ flag. If nothing should be excluded leave the field empty. This would also fix #115.

Furthermore i added a debug output for all loaded collectors before starting.

Hope this helps!